### PR TITLE
Revert "Change method update_attribute -> update for user.rb"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
 
   def remembers
     self.remember_token = User.new_token
-    update(:remember_digest, User.digest(remember_token))
+    update_attribute(:remember_digest, User.digest(remember_token))
   end
 
   def authenticated?(attribute,token)
@@ -41,12 +41,12 @@ class User < ApplicationRecord
   end
 
   def forgets
-    update(:remember_digest, nil)
+    update_attribute(:remember_digest, nil)
   end
 
   def activate
-    update(:activated, true)
-    update(:activated_at, Time.zone.now)
+    update_attribute(:activated, true)
+    update_attribute(:activated_at, Time.zone.now)
   end
 
   def send_activation_email
@@ -55,8 +55,8 @@ class User < ApplicationRecord
 
   def create_reset_digest
     self.reset_token = User.new_token
-    update(:reset_digest,  User.digest(reset_token))
-    update(:reset_sent_at, Time.zone.now)
+    update_attribute(:reset_digest,  User.digest(reset_token))
+    update_attribute(:reset_sent_at, Time.zone.now)
   end
 
   def send_password_reset_email


### PR DESCRIPTION
This reverts commit fe70111a190192a98ef34e0e9a455cf0d52adf88.

update_attribute を updateに変更するとエラーが発生したため、一旦戻しました。
update_attributeを使用しないで書くには、update_attributeを使用していた箇所をupdateに置き換え新たにvalidationを書くしかないと思っていますがあってますでしょうか。
宜しくお願い致します。