### PR TITLE
update: bundle update --bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,4 +515,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
warning: constant Gem::ConfigMap is deprecated
上記のエラーを吐いたため。